### PR TITLE
Simplify build.rs massively

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "ISC"
 [dependencies]
 thiserror = "1"
 lazy_static = "1"
-llvm-sys = {version = "130", features=["no-llvm-linking"]}
+llvm-sys = "130"
 
 [package.metadata.docs.rs]
 features = [ "docs-rs" ]

--- a/build.rs
+++ b/build.rs
@@ -1,70 +1,11 @@
-#[cfg(target_os = "macos")]
-use std::os::unix::fs::PermissionsExt;
-
 #[cfg(feature = "docs-rs")]
 fn main() {}
 
 #[cfg(not(feature = "docs-rs"))]
 fn main() {
-    let output = std::process::Command::new(std::env::var("LLVM_CONFIG").unwrap_or_else(|_| {
-        std::env::var("DEP_LLVM_CONFIG_PATH").unwrap_or_else(|_| "llvm-config".to_string())
-    }))
-    .arg("--prefix")
-    .output()
-    .unwrap()
-    .stdout;
-
-    #[cfg(not(target_os = "macos"))]
-    let shared_lib = "so";
-
-    #[cfg(target_os = "macos")]
-    let shared_lib = "dylib";
-
-    let out_dir = std::path::PathBuf::from(std::env::var("OUT_DIR").unwrap());
-    let prefix = std::path::PathBuf::from(String::from_utf8(output).unwrap().trim());
-
-    // Copy LTO lib
-    let lto_file_name = format!("libLTO.{}", shared_lib);
-    let lto = prefix.join("lib").join(&lto_file_name);
-
-    let out_file = out_dir.join(&lto_file_name);
-    std::fs::copy(&lto, &out_file).unwrap();
-
-    #[cfg(target_os = "macos")]
-    {
-        let meta = std::fs::metadata(&out_file).unwrap();
-        let mut permissions = meta.permissions();
-        permissions.set_mode(0o755);
-        std::fs::set_permissions(&out_file, permissions).unwrap();
+    if cfg!(not(target_os = "windows")) {
+        println!("cargo:rustc-link-lib=ffi");
+        println!("cargo:rustc-link-lib=LLVM");
+        println!("cargo:rustc-link-lib=LTO");
     }
-
-    #[cfg(not(target_os = "macos"))]
-    {
-        if let Ok(lto_full) = std::fs::read_link(&lto) {
-            std::fs::copy(
-                prefix.join("lib").join(&lto_full),
-                out_dir.join(lto_full.file_name().unwrap()),
-            )
-            .unwrap();
-        }
-    }
-
-    // Copy LLVM lib
-    let llvm_file_name = format!("libLLVM.{}", shared_lib);
-    let out_file = out_dir.join(&llvm_file_name);
-    println!("FILENAME: {}", llvm_file_name);
-    println!("PREFIX: {}", prefix.display());
-    std::fs::copy(prefix.join("lib").join(&llvm_file_name), &out_file).unwrap();
-
-    #[cfg(target_os = "macos")]
-    {
-        let meta = std::fs::metadata(&out_file).unwrap();
-        let mut permissions = meta.permissions();
-        permissions.set_mode(0o755);
-        std::fs::set_permissions(&out_file, permissions).unwrap();
-    }
-
-    println!("cargo:rustc-link-search=native={}", out_dir.display());
-    println!("cargo:rustc-link-lib=LLVM");
-    println!("cargo:rustc-link-lib=LTO");
 }


### PR DESCRIPTION
Now it doesn't try to link via llvm-config on its own, rather reusing
the linking logic from llvm-sys. It simply sets proper linking for
libffi.

(BTW, this means the `no-llvm-linking` feature is also removed from the `llvm-sys` dependency.)

It's pretty much the same `build.rs` as `inkwell`'s now. I think it may be possible to even remove the docs-rs workaround now.

On the way, fixes https://github.com/zshipko/llama/issues/10 and makes compilation on NixOS _much_ easier.