### PR TITLE
Fix build script to use `llvm-config --libdir` instead of `$(llvm-config --prefix)/lib`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -9,7 +9,7 @@ fn main() {
     let output = std::process::Command::new(std::env::var("LLVM_CONFIG").unwrap_or_else(|_| {
         std::env::var("DEP_LLVM_CONFIG_PATH").unwrap_or_else(|_| "llvm-config".to_string())
     }))
-    .arg("--prefix")
+    .arg("--libdir")
     .output()
     .unwrap()
     .stdout;
@@ -21,11 +21,11 @@ fn main() {
     let shared_lib = "dylib";
 
     let out_dir = std::path::PathBuf::from(std::env::var("OUT_DIR").unwrap());
-    let prefix = std::path::PathBuf::from(String::from_utf8(output).unwrap().trim());
+    let libdir = std::path::PathBuf::from(String::from_utf8(output).unwrap().trim());
 
     // Copy LTO lib
     let lto_file_name = format!("libLTO.{}", shared_lib);
-    let lto = prefix.join("lib").join(&lto_file_name);
+    let lto = libdir.join(&lto_file_name);
 
     let out_file = out_dir.join(&lto_file_name);
     std::fs::copy(&lto, &out_file).unwrap();
@@ -42,7 +42,7 @@ fn main() {
     {
         if let Ok(lto_full) = std::fs::read_link(&lto) {
             std::fs::copy(
-                prefix.join("lib").join(&lto_full),
+                libdir.join(&lto_full),
                 out_dir.join(lto_full.file_name().unwrap()),
             )
             .unwrap();
@@ -53,8 +53,8 @@ fn main() {
     let llvm_file_name = format!("libLLVM.{}", shared_lib);
     let out_file = out_dir.join(&llvm_file_name);
     println!("FILENAME: {}", llvm_file_name);
-    println!("PREFIX: {}", prefix.display());
-    std::fs::copy(prefix.join("lib").join(&llvm_file_name), &out_file).unwrap();
+    println!("LIBDIR: {}", libdir.display());
+    std::fs::copy(libdir.join(&llvm_file_name), &out_file).unwrap();
 
     #[cfg(target_os = "macos")]
     {


### PR DESCRIPTION
This fixes compilation on NixOS so that no hacky replacement of `llvm-config` is needed.

In Ubuntu, the output of `llvm-config --libdir` is the same as that of `$(llvm-config --prefix)/lib`; however, this is not the case in NixOS (and I imagine it also isn't the case in a handful of other places):

```
$ llvm-config --prefix
/nix/store/q0hkk4v3b5k3ivf93d9h2gag8khnpxsj-llvm-13.0.0-dev
$ llvm-config --libdir
/nix/store/9439qfdrb6c3d8si7h5qn4v4zvfwhwc2-llvm-13.0.0-lib/lib
```

In the build script, what we really want is `--libdir`, as that is where all the shared libraries are located.

I've checked that not only does this work trivially in NixOS, it also just works on Ubuntu (tested on a 21.04 VM).

This fixes https://github.com/zshipko/llama/issues/10.