### PR TITLE
Add checks in build script to only copy shared libs if they weren't already copied

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -28,7 +28,9 @@ fn main() {
     let lto = libdir.join(&lto_file_name);
 
     let out_file = out_dir.join(&lto_file_name);
-    std::fs::copy(&lto, &out_file).unwrap();
+    if !out_file.exists() {
+        std::fs::copy(&lto, &out_file).unwrap();
+    }
 
     #[cfg(target_os = "macos")]
     {
@@ -41,11 +43,10 @@ fn main() {
     #[cfg(not(target_os = "macos"))]
     {
         if let Ok(lto_full) = std::fs::read_link(&lto) {
-            std::fs::copy(
-                libdir.join(&lto_full),
-                out_dir.join(lto_full.file_name().unwrap()),
-            )
-            .unwrap();
+            let out_file = out_dir.join(lto_full.file_name().unwrap());
+            if !out_file.exists() {
+                std::fs::copy(libdir.join(&lto_full), out_file).unwrap();
+            }
         }
     }
 
@@ -54,7 +55,9 @@ fn main() {
     let out_file = out_dir.join(&llvm_file_name);
     println!("FILENAME: {}", llvm_file_name);
     println!("LIBDIR: {}", libdir.display());
-    std::fs::copy(libdir.join(&llvm_file_name), &out_file).unwrap();
+    if !out_file.exists() {
+        std::fs::copy(libdir.join(&llvm_file_name), &out_file).unwrap();
+    }
 
     #[cfg(target_os = "macos")]
     {


### PR DESCRIPTION
Back to the build script again :sweat_smile: 

So, since our work yesterday I've been noticing a very weird behaviour that, if I ran `cargo clean`, `cargo build` and then `cargo clippy` on my project, `cargo build` would work fine but `cargo clippy` wouldn't. The other way around, if I ran `cargo clippy` before I ran `cargo build`, then `cargo clippy` worked but `cargo build` failed. As you can imagine, this was extremely annoying. (Well, it's still better than before, essentially not building at all...)

In both cases, it failed in the first call to `std::fs::copy`, with a "permission denied" error.
What happens is that when the copy is done, it is preserved for later executions (since it is in the `$OUT_DIR`). However, it has only read permissions, and so can't be overwritten when the build script is re-run.

In this PR I just added checks to only run the `std::fs::copy`s if the file isn't already there, which solves the issue.

Also, this might mean that we no longer need that stuff with permissions for MacOS (not sure about that though -- I don't really understand why that is needed only on MacOS).